### PR TITLE
TEST2: initial commit of oiwfs-adc-assembly

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # TEST2-Model-Files
 
-This repository is for experiments and testing.
+This repository is for experiments and testing. It is based on an initial test version of the IRIS API
 

--- a/csro/oiwfs-adc-assembly/command-model.conf
+++ b/csro/oiwfs-adc-assembly/command-model.conf
@@ -1,0 +1,23 @@
+subsystem = TEST2
+component = oiwfs-adc-assembly
+
+description = "OIWFS ADC Assembly Commands."
+
+receive = [
+    {
+        name = FOLLOW_ADC
+        description = "Enable or disable following of TCS target streams."
+        requiredArgs = [isFollowing]
+        args = [
+            {
+                name = isFollowing
+                description = "Indicate which probe ADCs are following."
+                type = array
+                dimensions: [3]
+                items = {
+                      type = boolean
+                      }
+            }
+        ]
+    }
+]

--- a/csro/oiwfs-adc-assembly/component-model.conf
+++ b/csro/oiwfs-adc-assembly/component-model.conf
@@ -1,0 +1,12 @@
+subsystem = TEST2
+component = oiwfs-adc-assembly
+
+prefix = test2.oiwfs.adc
+modelVersion = "1.0"
+title = "OIWFS ADC"
+
+componentType = Assembly
+
+description = """
+The assembly controls the OIWFS POA ADCs. 
+"""

--- a/csro/oiwfs-adc-assembly/publish-model.conf
+++ b/csro/oiwfs-adc-assembly/publish-model.conf
@@ -1,0 +1,79 @@
+subsystem = TEST2
+component = oiwfs-adc-assembly
+
+publish {
+
+  description = """
+  The ADC assembly publishes the offsets that they incur so that the TCS can correctly positions the POAs.
+        """
+
+  telemetry = [
+    {
+      name = "oiwfs1WfsShift"
+      description = """
+The expected shifts of the IRIS OIWFS probe 1 position due to ADC effects in the X,Y plane of ICRS.
+            """
+      archive = true
+      attributes = [
+        {
+          name = x
+          description = "x offset"
+          type = double
+          units = mm
+        }
+        {
+          name = y
+          description = "y offset"
+          type = double
+          units = mm
+        }
+      ]
+    }
+
+    {
+      name = "oiwfs2WfsShift"
+      description = """
+The expected shifts of the IRIS OIWFS probe 2 position due to ADC effects in the X,Y plane of ICRS.
+            """
+      archive = true
+      attributes = [
+        {
+          name = x
+          description = "x offset"
+          type = double
+          units = mm
+        }
+        {
+          name = y
+          description = "y offset"
+          type = double
+          units = mm
+        }
+      ]
+    }
+
+    {
+      name = "oiwfs3WfsShift"
+      description = """
+The expected shifts of the IRIS OIWFS probe 3 position due to ADC effects in the X,Y plane of ICRS.
+            """
+      archive = true
+      attributes = [
+        {
+          name = x
+          description = "x offset"
+          type = double
+          units = mm
+        }
+        {
+          name = y
+          description = "y offset"
+          type = double
+          units = mm
+        }
+      ]
+    }
+
+  ]
+
+}

--- a/csro/oiwfs-adc-assembly/subscribe-model.conf
+++ b/csro/oiwfs-adc-assembly/subscribe-model.conf
@@ -1,0 +1,25 @@
+subsystem = TEST2
+component = oiwfs-adc-assembly
+
+subscribe {
+          telemetry = [
+          {
+          subsystem = TEST
+          component = cmIRIS
+          name = oiwfs1CurAtmDispersion
+          }
+
+          {
+          subsystem = TEST
+          component = cmIRIS
+          name = oiwfs2CurAtmDispersion
+          }
+
+          {
+          subsystem = TEST
+          component = cmIRIS
+          name = oiwfs3CurAtmDispersion
+          }
+
+          ]
+}

--- a/subsystem-model.conf
+++ b/subsystem-model.conf
@@ -1,0 +1,43 @@
+// ICD Subsystem
+
+subsystem = TEST2
+title = "INFRARED IMAGING SPECTROGRAPH (IRIS)"
+modelVersion = "1.0"
+
+description = """
+This is the API of the __InfraRed Imaging Spectrograph__
+(TMT.INS.INST.IRIS).
+
+IRIS is an integral field spectrometer and imager working at the TMT
+diffraction limit, and is fed by the Adaptive Optics Facility,
+NFIRAOS. IRIS will operate over the wavelength range 0.8-2.5µm, and it
+must have an internal wavefront error (after compensation by NFIRAOS)
+better than 35 nm RMS. The field of view of the Integral Field Unit
+(IFU) will be 2’’, and the field of view of the imager will be at
+least 10’’x10’’ and possibly as large as 30’’x30’’. The imaging field
+of view may not be contiguous. Concurrent imaging and IFU observation
+is a goal. Plate scale will be adjustable to 4, 9 25, and 50 mas. The
+IFU spectral resolution will be R=4000 over the entire J, H and K
+bands, one band at a time, and the imaging mode will have R = 2-50.
+
+IRIS will have a set of three NGS wavefront sensors [2 tip-tilt (TT) +
+one tip/tilt/focus (TTF)], collectively called the On-Instrument
+Wavefront Sensor (OIWFS). The NFIRAOS sky coverage specification
+requires that TT(F) measurements be made in the science focal plane,
+where AO corrections make it possible to use fainter reference guide
+stars (J<22). The three wavefront sensors will be able to patrol the
+full 2’ corrected field produced by NFIRAOS. Further AO corrections
+are provided by up to four On-Detector Guide Windows (for NGSs on the
+IRIS Imager itself).
+
+An instrument rotator is used to compensate for the combination of
+sidereal rotation (changing parallactic angle between celestial and
+Alt-Az coordinates), and pupil rotation as the zenith angle changes.
+
+The OIWFS, ODGWs, and rotator are commanded by the AO Sequencer (AOSQ,
+part of the AO Executive Software), and follow demand streams produced
+by the TCS.
+
+All environmental control of IRIS is handled by the IRIS Instrument
+Sequencer. 
+"""


### PR DESCRIPTION
This is based on the IRIS oiwfs-adc-assembly, and will require streams to be published by TEST (dummy TCS).
